### PR TITLE
Adds missing sqlite3 dependency to list of deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Setup dependencies
     go get github.com/stretchr/testify
     go get github.com/vektra/mockery/.../
     go get github.com/afex/hystrix-go/hystrix
+    go get -u github.com/mattn/go-sqlite3
 
 Setup sqlite data structure
 


### PR DESCRIPTION
Added `go get -u github.com/mattn/go-sqlite3` to list of dependencies in order to get the tests to run from a clean machine.